### PR TITLE
V1.1 Launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,33 +4,3 @@
 
 ### Project ###
 map.js
-
-### macOS ###
-# General
-.DS_Store
-.AppleDouble
-.LSOverride
-
-# Icon must end with two \r
-Icon
-
-# Thumbnails
-._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-.com.apple.timemachine.donotpresent
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
-
-# End of https://www.toptal.com/developers/gitignore/api/macos

--- a/main.js
+++ b/main.js
@@ -1,43 +1,52 @@
 function clickOnElement(element) {
-    var bounding_box = element.getBoundingClientRect();
-    var x = (bounding_box.left + bounding_box.right) / 2;
-    var y = (bounding_box.top + bounding_box.bottom) / 2;
-    document.elementFromPoint(x, y).click();
+  var bounding_box = element.getBoundingClientRect();
+  var x = (bounding_box.left + bounding_box.right) / 2;
+  var y = (bounding_box.top + bounding_box.bottom) / 2;
+  document.elementFromPoint(x, y).click();
 }
 
-document.body.addEventListener('input', function(event) {
-    typed_string = event.target.value
-    if (typed_string.includes('#')) {
-        // Get indices of (first) tag
-        index_start = typed_string.lastIndexOf('#');
-        index_end = typed_string.indexOf(' ', index_start);
-        if (index_end == -1) index_end = typed_string.length;
-        
-        // Map tag to calendar 
-        tag = typed_string.substring(index_start+1, index_end);
-        calendar_id = map_tag_to_calendar_id[tag];
-        
-        // Select calendar using simulated clicks
-        if (calendar_id !== undefined) {
-            // Click on the calendar group
-            elements = document.getElementsByClassName('Lvl1Vd');
-            clickOnElement(elements.item(elements.length - 1));
-            
-            // Click on the calendar dropdown
-            setTimeout(() => {
-                element = document.getElementById('xCalSel');
-                clickOnElement(element);
-            }, 10);
+document.body.addEventListener("input", function (event) {
+  typed_string = event.target.value;
+  if (typed_string.includes("#")) {
+    // Get indices of (first) tag
+    index_start = typed_string.lastIndexOf("#");
+    index_end = typed_string.indexOf(" ", index_start);
+    if (index_end == -1) index_end = typed_string.length;
 
-            // Click on the calendar
-            setTimeout(() => {
-                elements = document.querySelectorAll('[data-value="' + calendar_id + '"]');
-                clickOnElement(elements.item(elements.length - 1));
-            }, 300);
- 
-            // Remove tag from event title
-            var re = new RegExp(" ?#" + tag)
-            event.target.value = typed_string.replace(re, '');
-        }
+    // Map tag to calendar
+    tag = typed_string.substring(index_start + 1, index_end);
+    calendar_id = map_tag_to_calendar_id[tag];
+
+    // Select calendar using simulated clicks
+    if (calendar_id !== undefined) {
+      // Click on the calendar group (only inline)
+      elements = document.getElementsByClassName("Lvl1Vd");
+      if (elements.length > 0) {
+        clickOnElement(elements.item(elements.length - 1));
+      }
+
+      // Click on the calendar dropdown
+      setTimeout(() => {
+        element = document.getElementById("xCalSel");
+        clickOnElement(element);
+      }, 10);
+
+      // Click on the calendar
+      setTimeout(() => {
+        elements = document.querySelectorAll(
+          '[data-value="' + calendar_id + '"]'
+        );
+        clickOnElement(elements.item(elements.length - 1));
+      }, 300);
+
+      // Remove tag from event title
+      var re = new RegExp(" ?#" + tag);
+      event.target.value = typed_string.replace(re, "");
+
+      // Focus on event title
+      setTimeout(() => {
+        event.target.focus();
+      }, 600);
     }
+  }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
   {
     "name": "Weeds",
-    "version": "1.0",
+    "version": "1.1",
     "description": "Easily change calendars when creating new events in Google Calendar",
-    "manifest_version": 2,
+    "manifest_version": 3,
     "content_scripts": [ {
         "matches": ["https://calendar.google.com/*"],
         "js": ["map.js", "main.js"]

--- a/map-example.js
+++ b/map-example.js
@@ -1,11 +1,10 @@
-// After cloning this repository, rename this file to `map.js`.
-// You can modify the tags `personal`, `work`, and `todo` and add your own.
-// You can find the calendar IDs in the Integrate Calender section of calendar settings.
-// The calendar ID is the string preceding the `@group.calendar.google.com`.
-// Nothing stops from multiple tags mapping to the same calendar ID.
+// After cloning this repository, rename this file to `map.js`. You can modify the tags
+// `personal`, `work`, and `todo` and map them to your own calendar IDs. Multiple tags
+// can be mapped to the same calendar ID. The calendar IDs are the `data-value`
+// attributes of the calendar elements in the dropdown menu.
 
 map_tag_to_calendar_id = {
-    'personal': 'sample_calendar_id',
-    'work': 'another_sample_calendar_id',
-    'todo': 'third_sample_calendar_id'
-}
+  personal: "sample_calendar_id",
+  work: "another_sample_calendar_id",
+  todo: "third_sample_calendar_id",
+};


### PR DESCRIPTION
- [x] After selecting the event in the inline editor, refocus the name field (so pressing `Enter` will save the event)
- [x] Support for the full screen event editor
- [x] Updated documentation to be consistent with new `div` names